### PR TITLE
NEED-JIRA: pn_message_send() simplified message sending for C programs.

### DIFF
--- a/c/examples/send.c
+++ b/c/examples/send.c
@@ -38,6 +38,7 @@ typedef struct app_data_t {
   int message_count;
 
   pn_proactor_t *proactor;
+  pn_message_t *message;
   pn_rwbytes_t message_buffer;
   int sent;
   int acknowledged;
@@ -55,39 +56,20 @@ static void check_condition(pn_event_t *e, pn_condition_t *cond) {
 }
 
 /* Create a message with a map { "sequence" : number } encode it and return the encoded buffer. */
-static pn_bytes_t encode_message(app_data_t* app) {
+static void send_message(app_data_t* app, pn_link_t *sender) {
   /* Construct a message with the map { "sequence": app.sent } */
-  pn_message_t* message = pn_message();
-  pn_data_t* body = pn_message_body(message);
-  pn_data_put_int(pn_message_id(message), app->sent); /* Set the message_id also */
+  pn_data_t* body;
+  pn_message_clear(app->message);
+  body = pn_message_body(app->message);
+  pn_data_put_int(pn_message_id(app->message), app->sent); /* Set the message_id also */
   pn_data_put_map(body);
   pn_data_enter(body);
   pn_data_put_string(body, pn_bytes(sizeof("sequence")-1, "sequence"));
   pn_data_put_int(body, app->sent); /* The sequence number */
   pn_data_exit(body);
-
-  /* encode the message, expanding the encode buffer as needed */
-  if (app->message_buffer.start == NULL) {
-    static const size_t initial_size = 128;
-    app->message_buffer = pn_rwbytes(initial_size, (char*)malloc(initial_size));
-  }
-  /* app->message_buffer is the total buffer space available. */
-  /* mbuf wil point at just the portion used by the encoded message */
-  {
-  pn_rwbytes_t mbuf = pn_rwbytes(app->message_buffer.size, app->message_buffer.start);
-  int status = 0;
-  while ((status = pn_message_encode(message, mbuf.start, &mbuf.size)) == PN_OVERFLOW) {
-    app->message_buffer.size *= 2;
-    app->message_buffer.start = (char*)realloc(app->message_buffer.start, app->message_buffer.size);
-    mbuf.size = app->message_buffer.size;
-    mbuf.start = app->message_buffer.start;
-  }
-  if (status != 0) {
-    fprintf(stderr, "error encoding message: %s\n", pn_error_text(pn_message_error(message)));
+  if (pn_message_send(app->message, sender, &app->message_buffer) < 0) {
+    fprintf(stderr, "error sending message: %s\n", pn_error_text(pn_message_error(app->message)));
     exit(1);
-  }
-  pn_message_free(message);
-  return pn_bytes(mbuf.size, mbuf.start);
   }
 }
 
@@ -116,10 +98,7 @@ static bool handle(app_data_t* app, pn_event_t* event) {
        ++app->sent;
        /* Use sent counter as unique delivery tag. */
        pn_delivery(sender, pn_dtag((const char *)&app->sent, sizeof(app->sent)));
-       {
-       pn_bytes_t msgbuf = encode_message(app);
-       pn_link_send(sender, msgbuf.start, msgbuf.size);
-       }
+       send_message(app, sender);
        pn_link_advance(sender);
      }
      break;
@@ -193,6 +172,7 @@ int main(int argc, char **argv) {
   app.port = (argc > 2) ? argv[2] : "amqp";
   app.amqp_address = (argc > 3) ? argv[3] : "examples";
   app.message_count = (argc > 4) ? atoi(argv[4]) : 10;
+  app.message = pn_message();
 
   app.proactor = pn_proactor();
   pn_proactor_addr(addr, sizeof(addr), app.host, app.port);
@@ -200,5 +180,6 @@ int main(int argc, char **argv) {
   run(&app);
   pn_proactor_free(app.proactor);
   free(app.message_buffer.start);
+  pn_message_free(app.message);
   return exit_code;
 }

--- a/c/include/proton/message.h
+++ b/c/include/proton/message.h
@@ -723,7 +723,7 @@ PN_EXTERN pn_data_t *pn_message_body(pn_message_t *msg);
 PN_EXTERN int pn_message_decode(pn_message_t *msg, const char *bytes, size_t size);
 
 /**
- * Encode/save message content as AMQP formatted binary data.
+ * Encode a message as AMQP formatted binary data.
  *
  * If the buffer space provided is insufficient to store the content
  * held in the message, the operation will fail and return a
@@ -736,6 +736,22 @@ PN_EXTERN int pn_message_decode(pn_message_t *msg, const char *bytes, size_t siz
  * @return zero on success or an error code on failure
  */
 PN_EXTERN int pn_message_encode(pn_message_t *msg, char *bytes, size_t *size);
+
+struct pn_link_t;
+
+/**
+ * Encode and send a message on a sender link.
+ *
+ * @param[in] msg A message object.
+ * @param[in] sender A sending link, the message will be encoded and sent with pn_link_send(sender...)
+ * @param[inout] buffer Used to encode the message.
+ * If buffer == NULL, temporary space for encoding will be allocated/freed with malloc()/free()
+ * Otherwise the space indicated by buffer will be used to encode the message.
+ * If buffer is not large enough, it will be extended with realloc()
+ * @return The number of bytes sent on success, an error code (< 0) on failure.
+ * pn_message_error(msg) will have further error information.
+ */
+PN_EXTERN ssize_t pn_message_send(pn_message_t *msg, pn_link_t *sender, pn_rwbytes_t *buffer);
 
 /**
  * Save message content into a pn_data_t object data. The data object will first be cleared.


### PR DESCRIPTION
Encapsulates the awkward allocate-encode-expand dance required by pn_message_encode()
Supports the following 2 scenarios:

1. Simple: don't care about allocations, just send `pn_message_t *msg` and forget it:

    pn_message_send(msg, sender, NULL)

2. Efficient: re-use a buffer, buffer is allocated and expanded as required:

    pn_rwbytes_t buffer={0};     // Zero initialize, libary will do the allocation
    ...
    pn_message_send(msg, sender, &buffer); // Expand as needed
    pn_message_send(msg2, sender2, &buffer); // etc.
    ...
    free(buffer->start);        // Application must do final free of buffer

Note 2. assumes use of malloc/realloc/free, apps that need custom allocation can
use the original pn_message_encode() API or we could add a version that takes a pointer
to a function equivalent to realloc()